### PR TITLE
Bump @koa/cors to v5

### DIFF
--- a/lib/shared/cors.js
+++ b/lib/shared/cors.js
@@ -20,7 +20,13 @@ function checkClientCORS(ctx, client) {
 }
 
 module.exports = ({ clientBased = false, ...options }) => {
-  const builtin = cors({ keepHeadersOnError: false, ...options });
+  const builtin = cors({
+    keepHeadersOnError: false,
+    origin(ctx) {
+      return ctx.get('Origin') || '*';
+    },
+    ...options,
+  });
 
   return async (ctx, next) => {
     const headers = Object.keys(ctx.response.headers);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "7.14.3",
       "license": "MIT",
       "dependencies": {
-        "@koa/cors": "^3.3.0",
+        "@koa/cors": "^5.0.0",
         "cacheable-lookup": "^6.0.4",
         "debug": "^4.3.4",
-        "ejs": "^3.1.8",
+        "ejs": "^3.1.10",
         "got": "^11.8.5",
         "jose": "^4.10.3",
         "jsesc": "^3.0.2",
@@ -725,14 +725,14 @@
       }
     },
     "node_modules/@koa/cors": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-3.4.3.tgz",
-      "integrity": "sha512-WPXQUaAeAMVaLTEFpoq3T2O1C+FstkjJnDQqy95Ck1UdILajsRhu6mhJ8H2f4NFPRBoCNN+qywTJfq/gGki5mw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-5.0.0.tgz",
+      "integrity": "sha512-x/iUDjcS90W69PryLDIMgFyV21YLTnG9zOpPXS7Bkt2b8AsY3zZsIpOLBkYr9fBcF3HbkKaER5hOBZLfpLgYNw==",
       "dependencies": {
         "vary": "^1.1.2"
       },
       "engines": {
-        "node": ">= 8.0.0"
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@koa/ejs": {
@@ -1799,9 +1799,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/ejs": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
-      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "dependencies": {
         "jake": "^10.8.5"
       },

--- a/package.json
+++ b/package.json
@@ -55,10 +55,10 @@
     "test": "node ./test/run"
   },
   "dependencies": {
-    "@koa/cors": "^3.3.0",
+    "@koa/cors": "^5.0.0",
     "cacheable-lookup": "^6.0.4",
     "debug": "^4.3.4",
-    "ejs": "^3.1.8",
+    "ejs": "^3.1.10",
     "got": "^11.8.5",
     "jose": "^4.10.3",
     "jsesc": "^3.0.2",


### PR DESCRIPTION
- avoid a npm vulnerability using oidc-provider

Made the changes regarding the breaking changes in @koa/cors 5: https://www.npmjs.com/package/@koa/cors#breaking-change-between-50-and-40